### PR TITLE
Fix 500 when user's session got expired

### DIFF
--- a/src/Controller/WhoIsEditingController.php
+++ b/src/Controller/WhoIsEditingController.php
@@ -38,7 +38,13 @@ class WhoIsEditingController extends Base
      */
     public function getEditorsActions(Application $app, Request $request)
     {
-        $userId = $app['users']->getCurrentUser()['id'];
+        $user = $app['users']->getCurrentUser();
+        if (!$user) {
+            //user is not logged in, so show nothing in widget and let Bolt do redirect to login page
+            return new Response();
+        }
+        
+        $userId = $user['id'];
         $recordId = $request->query->get('recordID');
         $contenttype = $request->query->get('contenttype');
         $hoursToSubstract = $app['whoisediting.config']['lastActions'];


### PR DESCRIPTION
Fixes:

An exception has been thrown during the rendering of a template ("Impossible to access an attribute ("id") on a null variable in "@whoisediting/no_actions.twig" at line 5.") in "@bolt/editcontent/_aside.twig" at line 3.