### PR TITLE
Revert #16 because it's handled in #17

### DIFF
--- a/src/Controller/WhoIsEditingController.php
+++ b/src/Controller/WhoIsEditingController.php
@@ -39,11 +39,6 @@ class WhoIsEditingController extends Base
     public function getEditorsActions(Application $app, Request $request)
     {
         $user = $app['users']->getCurrentUser();
-        if (!$user) {
-            //user is not logged in, so show nothing in widget and let Bolt do redirect to login page
-            return new Response();
-        }
-        
         $userId = $user['id'];
         $recordId = $request->query->get('recordID');
         $contenttype = $request->query->get('contenttype');


### PR DESCRIPTION
The empty response broke the token check.

The 500 error is handled by the token check too - you now get a message statin that the token has expired.